### PR TITLE
Refactored, now using xcrun, input/output now in tmp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed need for Xcode path
 * Now using 'xcrun' command
 * Input/Output now handled in temp folder/files
+* No need to save .swift file before executing
 * No file will be created in your project directory
 * Keymap added
 * Refactored plugin code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed
+
+## 0.2.0 - Second Release
+* Removed need for Xcode path
+* Now using 'xcrun' command
+* Input/Output now handled in temp folder/files
+* No file will be created in your project directory
+* Keymap added
+* Refactored plugin code

--- a/keymaps/swift-playground.cson
+++ b/keymaps/swift-playground.cson
@@ -1,2 +1,2 @@
-'.platform-darwin .editor, .platform-win32 .editor, .platform-linux .editor':
+'.platform-darwin .editor':
   'ctrl-shift-c': 'swift-playground:execute'

--- a/keymaps/swift-playground.cson
+++ b/keymaps/swift-playground.cson
@@ -1,2 +1,2 @@
 '.platform-darwin .editor':
-  'ctrl-shift-c': 'swift-playground:execute'
+  'ctrl-alt-cmd-w': 'swift-playground:execute'

--- a/keymaps/swift-playground.cson
+++ b/keymaps/swift-playground.cson
@@ -1,0 +1,2 @@
+'.platform-darwin .editor, .platform-win32 .editor, .platform-linux .editor':
+  'ctrl-shift-c': 'swift-playground:execute'

--- a/lib/swift_playground.coffee
+++ b/lib/swift_playground.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 
 module.exports =
   configDefaults:
-    swift_path: '/Applications/Xcode6-Beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift'
+    xcode_path: '/Applications/Xcode6-Beta.app'
 
   activate: ->
     atom.workspaceView.command "swift-playground:execute", => @execute()
@@ -20,8 +20,9 @@ module.exports =
     output_file_path = "#{atom.project.getPath()}/#{editor.getTitle()}.out"
 
     # evaluate swift
-    command = atom.config.get('swift-playground.swift_path')
-    args = ["-i", current_file_path]
+    xcode = atom.config.get('swift-playground.xcode_path')
+    command = "#{xcode}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
+    args = ["-sdk", "#{xcode}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk", current_file_path]
     stdout = (output) => @write_and_open_file(output_file_path, output)
     stderr = stdout
     process = new BufferedProcess({command, args, stdout, stderr})
@@ -34,14 +35,10 @@ module.exports =
       else
         options = {
           split: 'right'
-
-          # TODO not working??
-          activatePane: false
         }
 
         activePane = atom.workspace.getActivePane()
         atom.workspace.open(path, options).done((newEditor)->
-          # options.activatePane seems not to work, so reactivate prev pane.
-          activePane.activate()
+            activePane.activate()
         )
     )

--- a/lib/swift_playground.coffee
+++ b/lib/swift_playground.coffee
@@ -15,7 +15,7 @@ module.exports =
       fs.writeFile outputFilePath, output, (error)->
         throw error if error
         activePane = atom.workspace.getActivePane()
-        atom.workspace.open(outputFilePath, {split: 'right'}).done (newEditor) -> activePane.activate()
+        atom.workspace.open(outputFilePath, {split: 'right', activatePane: no}).done (newEditor) -> activePane.activate()
     stderr = stdout
     new BufferedProcess {
       command: "xcrun",

--- a/lib/swift_playground.coffee
+++ b/lib/swift_playground.coffee
@@ -2,43 +2,21 @@
 fs = require 'fs'
 
 module.exports =
-  configDefaults:
-    xcode_path: '/Applications/Xcode6-Beta.app'
-
   activate: ->
     atom.workspaceView.command "swift-playground:execute", => @execute()
 
   execute: ->
-    editor = atom.workspace.getActiveEditor()
-
-    # unsaved file returns undefined
-    current_file_path = editor.getPath()
-    return unless current_file_path
-    unless current_file_path.match(/\.swift$/)
-      return console.log('The file extention is not matched.')
-
-    output_file_path = "#{atom.project.getPath()}/#{editor.getTitle()}.out"
-
-    # evaluate swift
-    xcode = atom.config.get('swift-playground.xcode_path')
-    command = "#{xcode}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
-    args = ["-sdk", "#{xcode}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk", current_file_path]
-    stdout = (output) => @write_and_open_file(output_file_path, output)
-    stderr = stdout
-    process = new BufferedProcess({command, args, stdout, stderr})
-
-  write_and_open_file: (path, output)->
-    fs.writeFile(path, output, (err)->
-      if err
-        console.error(err)
-
-      else
-        options = {
-          split: 'right'
-        }
-
-        activePane = atom.workspace.getActivePane()
-        atom.workspace.open(path, options).done((newEditor)->
-            activePane.activate()
-        )
-    )
+    outputDir = "#{atom.getConfigDirPath()}/.swift-playground"
+    fs.mkdir outputDir if not fs.existsSync outputDir
+    inputFilePath = "#{outputDir}/input.swift"
+    outputFilePath = "#{outputDir}/Swift Output"
+    fs.writeFile inputFilePath, atom.workspace.getActiveEditor().getText()
+    new BufferedProcess {
+      command: "xcrun",
+      args: ["swift", inputFilePath],
+      stdout: (output) =>
+        fs.writeFile outputFilePath, output, (error)->
+          throw error if error
+          activePane = atom.workspace.getActivePane()
+          atom.workspace.open(outputFilePath, {split: 'right'}).done (newEditor) -> activePane.activate()
+    }

--- a/lib/swift_playground.coffee
+++ b/lib/swift_playground.coffee
@@ -11,12 +11,15 @@ module.exports =
     inputFilePath = "#{outputDir}/input.swift"
     outputFilePath = "#{outputDir}/Swift Output"
     fs.writeFile inputFilePath, atom.workspace.getActiveEditor().getText()
+    stdout = (output) =>
+      fs.writeFile outputFilePath, output, (error)->
+        throw error if error
+        activePane = atom.workspace.getActivePane()
+        atom.workspace.open(outputFilePath, {split: 'right'}).done (newEditor) -> activePane.activate()
+    stderr = stdout
     new BufferedProcess {
       command: "xcrun",
       args: ["swift", inputFilePath],
-      stdout: (output) =>
-        fs.writeFile outputFilePath, output, (error)->
-          throw error if error
-          activePane = atom.workspace.getActivePane()
-          atom.workspace.open(outputFilePath, {split: 'right'}).done (newEditor) -> activePane.activate()
+      stdout,
+      stderr
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-playground",
   "main": "./lib/swift_playground",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Execute the current file with Swift.",
   "activationEvents": [
     "swift-playground:execute"


### PR DESCRIPTION
Among the following changes, I also upped the package.json version and added the following details to the changelog file. This also fixes #1.

need to run "sudo xcode-select --switch /Applications/Xcode6-Beta.app/Contents/Developer/"
- Removed need for Xcode path
- Now using 'xcrun' command
- Input/Output now handled in temp folder/files
- No need to save .swift file before executing
- No file will be created in your project directory
- Keymap added
- Refactored plugin code
